### PR TITLE
refactor: api, sorting, rewards

### DIFF
--- a/src/api/leaderboard/getTop5Traders.ts
+++ b/src/api/leaderboard/getTop5Traders.ts
@@ -1,0 +1,19 @@
+export default async function getTop5Traders() {
+  const limit = 5
+  try {
+    const response = await fetch(
+      `https://testnet-api.marsprotocol.io/v2/perps_pnl?chain=neutron&field=total_pnl&order=desc&limit=${limit}`,
+    )
+    const data = await response.json()
+    const processedData = data.data.map((item: TraderData, index: number) => ({
+      ...item,
+      position: index + 1,
+      trader: `Trader ${item.account_id}`,
+    }))
+
+    return processedData
+  } catch (error) {
+    console.error('Could not fetch top traders data.', error)
+    return null
+  }
+}

--- a/src/api/leaderboard/getTopTraders.ts
+++ b/src/api/leaderboard/getTopTraders.ts
@@ -1,17 +1,26 @@
-export default async function getTopTraders(page: number) {
+export default async function getTopTraders(
+  page: number,
+  sortOrder: 'asc' | 'desc',
+  sortField: string,
+) {
   const limit = 6
   try {
     const response = await fetch(
-      `https://testnet-api.marsprotocol.io/v2/perps_pnl?chain=neutron&field=total_pnl&order=desc&limit=${limit}&page=${page}`,
+      `https://testnet-api.marsprotocol.io/v2/perps_pnl?chain=neutron&field=${sortField}&order=${sortOrder}&limit=${limit}&page=${page}`,
     )
     const data = await response.json()
     const offset = (page - 1) * limit
+    const totalEntries = data.total
 
-    const processedData = data.data.map((item: any, index: number) => ({
-      ...item,
-      position: offset + index + 1,
-      trader: `Trader ${item.account_id}`,
-    }))
+    const processedData = data.data.map((item: TraderData, index: number) => {
+      const position = sortOrder === 'desc' ? offset + index + 1 : totalEntries - offset - index
+
+      return {
+        ...item,
+        position,
+        trader: `Trader ${item.account_id}`,
+      }
+    })
 
     return { data: processedData, total: data.total }
   } catch (error) {

--- a/src/api/leaderboard/getTradersLiquidations.ts
+++ b/src/api/leaderboard/getTradersLiquidations.ts
@@ -5,21 +5,14 @@ export default async function getTradersLiquidations() {
       `https://testnet-api.marsprotocol.io/v2/liquidations/statistics?chain=neutron&product=creditmanager&limit=${limit}`,
     )
     const data = await response.json()
-    const accountsData = data.data[0].top_liquidated_accounts
-    const amountsData = data.data[0].top_liquidated_amounts
+    const topLiquidations = data.data[0].top_liquidated_amounts
 
-    const processedData = accountsData.map((accountItem: LiquidationAccount, index: number) => {
-      const amountItem = amountsData.find(
-        (item: LiquidationAccount) =>
-          item.liquidatee_account_id === accountItem.liquidatee_account_id,
-      )
-
+    const processedData = topLiquidations.map((liquidation: LiquidationAmount, index: number) => {
       return {
         position: index + 1,
-        account_id: accountItem.liquidatee_account_id,
-        number_liquidations: accountItem.liquidation_count,
-        total_liquidated_amount: amountItem ? amountItem.total_liquidated_amount : '0',
-        trader: `Trader ${accountItem.liquidatee_account_id}`,
+        account_id: liquidation.liquidatee_account_id,
+        total_liquidated_amount: liquidation.total_liquidated_amount,
+        trader: `Trader ${liquidation.liquidatee_account_id}`,
       }
     })
 

--- a/src/components/main/Leaderboard/LeaderboardTable.tsx
+++ b/src/components/main/Leaderboard/LeaderboardTable.tsx
@@ -7,11 +7,40 @@ import useTopTraderColumn from 'components/main/Leaderboard/table/useTopTradersC
 import useProjectedWinnersColumn from 'components/main/Leaderboard/table/useProjectedWinnersColumn'
 import useLiquidationsColumn from 'components/main/Leaderboard/table/useLiquidationsColumn'
 import { achievements } from 'components/main/Leaderboard/data'
+import useLiquidations from 'hooks/leaderboard/useTradersLiquidations'
+import useTop5Traders from 'hooks/leaderboard/useTop5Traders'
 
 export default function LeaderboardTable() {
   const topTradersColumns = useTopTraderColumn()
-  const projectedWinnersColumns = useProjectedWinnersColumn()
   const liquidationsColumns = useLiquidationsColumn()
+  const projectedWinnersColumns = useProjectedWinnersColumn()
+
+  const { data: liquidationsData } = useLiquidations()
+  const { data: top5Traders } = useTop5Traders()
+
+  const topLiquidation = useMemo(() => {
+    if (!liquidationsData || liquidationsData.length === 0) return null
+    return liquidationsData[0]
+  }, [liquidationsData])
+
+  const projectedWinners = useMemo(() => {
+    if (!top5Traders || !topLiquidation) return achievements
+
+    const top5WithAchievements = top5Traders.map((trader: TopTradersData, index: number) => ({
+      ...trader,
+      ...achievements[index],
+    }))
+
+    const combinedTraders = [
+      ...top5WithAchievements,
+      {
+        ...topLiquidation,
+        ...achievements[5],
+      },
+    ]
+
+    return combinedTraders
+  }, [top5Traders, topLiquidation])
 
   const tabs: CardTab[] = useMemo(() => {
     return [
@@ -26,11 +55,11 @@ export default function LeaderboardTable() {
       {
         title: 'Projected Winners',
         renderContent: () => (
-          <ProjectedWinners columns={projectedWinnersColumns} data={achievements} />
+          <ProjectedWinners columns={projectedWinnersColumns} data={projectedWinners} />
         ),
       },
     ]
-  }, [topTradersColumns, projectedWinnersColumns, liquidationsColumns])
+  }, [topTradersColumns, projectedWinnersColumns, liquidationsColumns, projectedWinners])
 
   if (!tabs.length) return null
 

--- a/src/components/main/Leaderboard/data.ts
+++ b/src/components/main/Leaderboard/data.ts
@@ -1,37 +1,31 @@
 export const achievements = [
   {
     achievement: 'Martian Champion',
-    metric: 'PnL',
     description: 'Top trader by PnL',
     reward: '$4 000 MARS',
   },
   {
     achievement: 'True Martian',
-    metric: 'PnL',
     description: 'Top 2nd trader by PnL',
     reward: '$2 500 MARS',
   },
   {
     achievement: 'Enemy of Mars (Reptilian)',
-    metric: 'PnL',
-    description: 'Last trader by PnL',
+    description: 'Top 3rd trader by PnL',
     reward: '$1 000 MARS',
   },
   {
     achievement: 'Jim Cramer on Mars',
-    metric: 'PnL',
-    description: 'Second to last trader by PnL',
-    reward: '$500 MARS',
+    description: 'Top 4th trader by PnL',
+    reward: '$800 MARS',
   },
   {
     achievement: 'Martian Donald Duck',
-    metric: 'Liquidations',
-    description: 'Most liquidations',
-    reward: '$1 000 MARS',
+    description: 'Top 5th trader by PnL',
+    reward: '$500 MARS',
   },
   {
     achievement: 'Lost in Space',
-    metric: 'Liquidations',
     description: 'Highest amount liquidated',
     reward: '$1 000 MARS',
   },

--- a/src/components/main/Leaderboard/data.ts
+++ b/src/components/main/Leaderboard/data.ts
@@ -17,7 +17,7 @@ export const achievements = [
   {
     achievement: 'Jim Cramer on Mars',
     description: 'Top 4th trader by PnL',
-    reward: '$800 MARS',
+    reward: '$1 000 MARS',
   },
   {
     achievement: 'Martian Donald Duck',

--- a/src/components/main/Leaderboard/table/TopTraders.tsx
+++ b/src/components/main/Leaderboard/table/TopTraders.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { ColumnDef } from '@tanstack/react-table'
+import { useEffect, useState } from 'react'
+import { ColumnDef, SortingState } from '@tanstack/react-table'
 import Table from 'components/common/Table'
 import Pagination from 'components/main/Leaderboard/table/Pagination'
 import useTopTraders from 'hooks/leaderboard/useTopTraders'
@@ -13,9 +13,14 @@ interface Props {
 export default function TopTraders(props: Props) {
   const { columns } = props
   const [page, setPage] = useState<number>(1)
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'total_pnl', desc: true }])
+
   const pageSize = 6
 
-  const { data: topTradersData, isLoading } = useTopTraders(page)
+  const sortOrder = sorting[0]?.desc ? 'desc' : 'asc'
+  const sortField = sorting[0]?.id || 'total_pnl'
+
+  const { data: topTradersData, isLoading } = useTopTraders(page, sortOrder, sortField)
   const maxEntries = topTradersData?.total || 0
 
   const totalPages = Math.ceil(maxEntries / pageSize)
@@ -23,6 +28,10 @@ export default function TopTraders(props: Props) {
   const handlePageChange = (newPage: number) => {
     setPage(newPage)
   }
+
+  useEffect(() => {
+    setPage(1)
+  }, [sorting])
 
   if (isLoading || !topTradersData || topTradersData.data.length === 0) {
     return (
@@ -50,7 +59,8 @@ export default function TopTraders(props: Props) {
         columns={columns}
         data={topTradersData.data}
         tableBodyClassName='text-xs'
-        initialSorting={[]}
+        initialSorting={sorting}
+        onSortingChange={setSorting}
         hideCard
       />
       {totalPages > 1 && (

--- a/src/components/main/Leaderboard/table/common/Position.tsx
+++ b/src/components/main/Leaderboard/table/common/Position.tsx
@@ -3,7 +3,6 @@ import Text from 'components/common/Text'
 export const POSITION_META = {
   id: 'position',
   header: 'Pos',
-  accessorKey: 'position',
   meta: { className: 'max-w-10' },
 }
 

--- a/src/components/main/Leaderboard/table/useLiquidationsColumn.tsx
+++ b/src/components/main/Leaderboard/table/useLiquidationsColumn.tsx
@@ -5,7 +5,6 @@ import Position, { POSITION_META } from 'components/main/Leaderboard/table/commo
 import DisplayCurrency from 'components/common/DisplayCurrency'
 import { BNCoin } from 'types/classes/BNCoin'
 import { BN } from 'utils/helpers'
-import { FormattedNumber } from 'components/common/FormattedNumber'
 
 export default function useLiquidationsColumn() {
   return useMemo<ColumnDef<LiquidationsData>[]>(() => {
@@ -17,7 +16,6 @@ export default function useLiquidationsColumn() {
         },
       },
       {
-        accessorKey: 'trader',
         header: 'Trader',
         meta: { className: 'max-w-30' },
         cell: ({ row }) => {
@@ -25,7 +23,6 @@ export default function useLiquidationsColumn() {
         },
       },
       {
-        accessorKey: 'account_id',
         header: 'Account ID',
         meta: { className: 'max-w-30' },
         cell: ({ row }) => {
@@ -33,8 +30,7 @@ export default function useLiquidationsColumn() {
         },
       },
       {
-        accessorKey: 'liquidations',
-        header: '$ Liquidated',
+        header: 'Amount Liquidated',
         cell: ({ row }) => {
           return (
             <DisplayCurrency
@@ -44,24 +40,6 @@ export default function useLiquidationsColumn() {
               }}
               showSignPrefix
               className='text-xs'
-            />
-          )
-        },
-      },
-      {
-        accessorKey: 'amount_of_liquidations',
-        header: '# Liquidations',
-        meta: { className: 'max-w-20' },
-        cell: ({ row }) => {
-          const amount = Number(row.original.number_liquidations)
-          return (
-            <FormattedNumber
-              amount={amount}
-              animate
-              options={{
-                minDecimals: 0,
-                maxDecimals: 0,
-              }}
             />
           )
         },

--- a/src/components/main/Leaderboard/table/useProjectedWinnersColumn.tsx
+++ b/src/components/main/Leaderboard/table/useProjectedWinnersColumn.tsx
@@ -6,11 +6,11 @@ export default function useProjectedWinnersColumn() {
   return useMemo<ColumnDef<ProjectedWinnersData>[]>(() => {
     return [
       {
-        accessorKey: 'metric',
-        header: 'Metric',
-        meta: { className: 'max-w-20' },
+        accessorKey: 'trader',
+        header: 'Trader',
+        meta: { className: 'max-w-30' },
         cell: ({ row }) => {
-          return <Account value={row.original.metric} />
+          return <Account value={row.original.trader ? row.original.trader : 'N/A'} />
         },
       },
       {

--- a/src/components/main/Leaderboard/table/useTopTradersColumn.tsx
+++ b/src/components/main/Leaderboard/table/useTopTradersColumn.tsx
@@ -17,7 +17,6 @@ export default function useTopTraderColumns() {
         },
       },
       {
-        accessorKey: 'trader',
         header: 'Trader',
         meta: { className: 'max-w-30' },
         cell: ({ row }) => {
@@ -25,7 +24,6 @@ export default function useTopTraderColumns() {
         },
       },
       {
-        accessorKey: 'account_id',
         header: 'Account ID',
         meta: { className: 'max-w-30' },
         cell: ({ row }) => {
@@ -34,6 +32,7 @@ export default function useTopTraderColumns() {
       },
       {
         accessorKey: 'total_pnl',
+        id: 'total_pnl',
         header: 'Profit & Loss (PnL)',
         cell: ({ row }) => {
           return (

--- a/src/hooks/leaderboard/useTop5Traders.ts
+++ b/src/hooks/leaderboard/useTop5Traders.ts
@@ -1,0 +1,8 @@
+import getTop5Traders from 'api/leaderboard/getTop5Traders'
+import useSWR from 'swr'
+
+export default function useTopTraders() {
+  return useSWR(['leaderboard/top5Traders'], async () => getTop5Traders(), {
+    refreshInterval: 60_000,
+  })
+}

--- a/src/hooks/leaderboard/useTopTraders.ts
+++ b/src/hooks/leaderboard/useTopTraders.ts
@@ -1,8 +1,12 @@
 import getTopTraders from 'api/leaderboard/getTopTraders'
 import useSWR from 'swr'
 
-export default function useTopTraders(page: number) {
-  return useSWR(['leaderboard/topTraders', page], async () => getTopTraders(page), {
-    refreshInterval: 60_000,
-  })
+export default function useTopTraders(page: number, sortOrder: 'asc' | 'desc', sortField: string) {
+  return useSWR(
+    ['leaderboard/topTraders', page, sortOrder, sortField],
+    async () => getTopTraders(page, sortOrder, sortField),
+    {
+      refreshInterval: 60_000,
+    },
+  )
 }

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -1416,6 +1416,14 @@ interface PoolInfo {
 }
 type ChartDataItem = { date: string; value: number }
 type ChartData = ChartDataItem[]
+
+interface TraderData {
+  account_id: string
+  realized_pnl: string
+  total_pnl: string
+  unrealized_pnl: string
+}
+
 interface TopTradersData {
   account_id: string
   realized_pnl: string
@@ -1425,8 +1433,8 @@ interface TopTradersData {
   trader: string
 }
 interface ProjectedWinnersData {
+  trader?: string
   achievement: string
-  metric: string
   description: string
   reward: string
 }
@@ -1437,11 +1445,6 @@ interface LiquidationsData {
   number_liquidations: string
   total_liquidated_amount: string
 }
-interface LiquidationAccount {
-  liquidatee_account_id: number
-  liquidation_count: number
-}
-
 interface LiquidationAmount {
   liquidatee_account_id: number
   total_liquidated_amount: string


### PR DESCRIPTION
- we can now sort top traders by pnl
- added winning traders into the projected winners table
- removed # liquidations
-  displaying $$ value of liquidations
-
<img width="778" alt="Screenshot 2024-11-02 at 7 11 37 PM" src="https://github.com/user-attachments/assets/cef191e9-0d3c-4b1b-9123-e19997b613cc">
<img width="756" alt="Screenshot 2024-11-02 at 7 08 11 PM" src="https://github.com/user-attachments/assets/869eddf9-e969-4b31-a1ce-6489e3901f89">
<img width="756" alt="Screenshot 2024-11-02 at 7 08 33 PM" src="https://github.com/user-attachments/assets/68426e58-cfdb-415c-98bf-bbadbba2eee2">
